### PR TITLE
fix: remove deprecated bottle field

### DIFF
--- a/Formula/pulsar.rb
+++ b/Formula/pulsar.rb
@@ -5,8 +5,6 @@ class Pulsar < Formula
   sha256 "aafd4a835ff100bde3df37220bfb950ce4dfb3c68f74680ba6c3bdd1cc3904cb"
   license "Apache-2.0"
 
-  bottle :unneeded
-
   depends_on "openjdk" => :optional
 
   def install

--- a/Formula/pulsarctl.rb
+++ b/Formula/pulsarctl.rb
@@ -2,7 +2,6 @@ class Pulsarctl < Formula
   desc "CLI for Apache Pulsar written in golang"
   homepage "https://streamnative.io/"
   license "Apache-2.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/Formula/snctl.rb
+++ b/Formula/snctl.rb
@@ -7,7 +7,6 @@ class Snctl < Formula
   homepage "https://streamnative.io/"
   version "0.10.1"
   license "Apache-2.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

`bottle :unneeded` will make a warning from Homebrew: `Warning: Calling bottle :unneeded is deprecated! There is no replacement.`
