### PR TITLE
Update pulsar.rb (use opt_bin)

### DIFF
--- a/Formula/pulsar.rb
+++ b/Formula/pulsar.rb
@@ -26,7 +26,7 @@ class Pulsar < Formula
   end
 
   service do
-    run [bin/"pulsar", "standalone"]
+    run [opt_bin/"pulsar", "standalone"]
     log_path var/"log/pulsar/output.log"
     error_log_path var/"log/pulsar/error.log"
   end


### PR DESCRIPTION
As seen in https://github.com/Homebrew/homebrew-core/pull/127462, the Pulsar formula should use `opt_bin` in the service block.